### PR TITLE
chore: align package description + README title to @geoql/v-mapkit

### DIFF
--- a/packages/v-mapkit/README.md
+++ b/packages/v-mapkit/README.md
@@ -1,4 +1,4 @@
-# V-Mapkit.js 🌎
+# @geoql/v-mapkit 🌎
 
 <!-- Badges -->
 
@@ -32,7 +32,7 @@ Power of [Vue 3](https://v3.vuejs.org) with awesomeness of [Mapkit](https://deve
 
 ## Table of Contents
 
-- [V-Mapkit.js 🌎](#v-mapkitjs-)
+- [@geoql/v-mapkit 🌎](#geoqlv-mapkit-)
   - [Features](#features)
   - [Table of Contents](#table-of-contents)
     - [Installation](#installation)

--- a/packages/v-mapkit/jsr.json
+++ b/packages/v-mapkit/jsr.json
@@ -1,7 +1,7 @@
 {
   "name": "@geoql/v-mapkit",
   "version": "0.3.0",
-  "description": "MapKit with the power of Vue 3 — Vue 3 components and composables for Apple MapKit JS.",
+  "description": "Vue 3 components for Apple MapKit JS - annotations, overlays, Look Around, search & geocoding, with full TypeScript support",
   "license": "MIT",
   "exports": {
     ".": "./dist/index.js"

--- a/packages/v-mapkit/package.json
+++ b/packages/v-mapkit/package.json
@@ -2,7 +2,7 @@
   "name": "@geoql/v-mapkit",
   "version": "0.3.0",
   "private": false,
-  "description": "MapKit with the power of Vue 3",
+  "description": "Vue 3 components for Apple MapKit JS - annotations, overlays, Look Around, search & geocoding, with full TypeScript support",
   "keywords": [
     "Apple MapKit",
     "Map Library",


### PR DESCRIPTION
Polish package metadata after the rename:

- npm + jsr `description`: concise capability summary matching the GitHub repo description + v-maplibre style (plain hyphen, no em-dash)
- README title `@geoql/v-mapkit` (was stale `V-Mapkit.js`)
- The jsr.json description syncs to the JSR package page on the next publish

Part of the v1 release polish (nitpicks alongside repo description/website + JSR settings).