### PR TITLE
fix(ci): upgrade npm before OIDC publish in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,6 +53,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Problem

The 1.0.0 publish job failed with `E404` on `PUT @geoql/v-mapkit@1.0.0` even though the signed provenance statement was published successfully:

```
npm notice publish Signed provenance statement ...
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@geoql%2fv-mapkit
npm error 404 ... could not be found or you do not have permission to access it.
```

## Root cause

Node 24.16 (our `.nvmrc`) ships **npm 11.4.x**, but npm OIDC trusted publishing requires **npm >= 11.5.1**. Older npm ignores the OIDC flow and falls back to the empty `NODE_AUTH_TOKEN` that `actions/setup-node` injects, producing a 404.

## Fix

Add `npm install -g npm@latest` before install/publish so the OIDC trusted publisher (already configured: `geoql/v-mapkit` → `release-please.yml`) actually engages.

## Context

The broken `v1.0.0` GitHub release + tag were deleted and `main` was reset to `0.3.0` (nothing published to npm/jsr — npm latest is still 0.3.0). After this merges, release-please re-cuts the 1.0.0 PR; merging it will publish via OIDC.